### PR TITLE
feat: Adjust fee mechanism

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -438,9 +438,15 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		// are 0. This avoids a negative effectiveTip being applied to
 		// the coinbase when simulating calls.
 	} else {
-		fee := new(big.Int).SetUint64(st.gasUsed())
-		fee.Mul(fee, effectiveTip)
-		st.state.AddBalance(st.evm.Context.Coinbase, fee)
+		priorityFee := new(big.Int).SetUint64(st.gasUsed())
+		priorityFee.Mul(priorityFee, effectiveTip)
+		st.state.AddBalance(st.evm.Context.Coinbase, priorityFee)
+
+		baseFee := new(big.Int).SetUint64(st.gasUsed())
+		baseFee.Mul(baseFee, st.evm.Context.BaseFee)
+
+		treasuryAccount := common.HexToAddress("0x0FD1bDBB92AF752a201A900e0E2bc68253C14b4c")
+		st.state.AddBalance(treasuryAccount, baseFee)
 	}
 
 	return &ExecutionResult{

--- a/geth-poa/util/test_fee.sh
+++ b/geth-poa/util/test_fee.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -x
+
+# For testing where fees are accumulated
+
+treasuryAcct=0x0FD1bDBB92AF752a201A900e0E2bc68253C14b4c
+
+# Before 
+tresuryBalance=$(cast balance $treasuryAcct)
+payerBalance=$(cast balance 0xBe3dEF3973584FdcC1326634aF188f0d9772D57D)
+signer1Balance=$(cast balance 0x788EBABe5c3dD422Ef92Ca6714A69e2eabcE1Ee4)
+signer2Balance=$(cast balance 0xd9cd8E5DE6d55f796D980B818D350C0746C25b97)
+receiverBalance=$(cast balance 0x110F2d06f045299Ed38fE8D1BdF172461Cd7B918)
+
+# Send tx
+cast send --private-key 0xc065f4c9a6dda0785e2224f5af8e473614de1c029acf094f03d5830e2dd5b0ea 0x110F2d06f045299Ed38fE8D1BdF172461Cd7B918 --value 0.1ether
+
+# After
+tresuryBalanceAfter=$(cast balance $treasuryAcct)
+payerBalanceAfter=$(cast balance 0xBe3dEF3973584FdcC1326634aF188f0d9772D57D)
+signer1BalanceAfter=$(cast balance 0x788EBABe5c3dD422Ef92Ca6714A69e2eabcE1Ee4)
+signer2BalanceAfter=$(cast balance 0xd9cd8E5DE6d55f796D980B818D350C0746C25b97)
+receiverBalanceAfter=$(cast balance 0x110F2d06f045299Ed38fE8D1BdF172461Cd7B918)
+
+# Print diff
+echo "Tresury balance diff: $(($tresuryBalanceAfter - $tresuryBalance))"
+echo "Payer balance diff: $(($payerBalanceAfter - $payerBalance))"
+echo "Signer1 balance diff: $(($signer1BalanceAfter - $signer1Balance))"
+echo "Signer2 balance diff: $(($signer2BalanceAfter - $signer2Balance))"
+echo "Receiver balance diff: $(($receiverBalanceAfter - $receiverBalance))"


### PR DESCRIPTION
Adjust fee mechanism to send baseFee to a hardcoded treasury account, tip still goes to signer. Note block rewards don't exist in POA so total supply remains constant. Output of included test script: 

```bash
+ echo 'Tresury balance diff: 147000'
Tresury balance diff: 147000
+ echo 'Payer balance diff: -100063000000147000'
Payer balance diff: -100063000000147000
+ echo 'Signer1 balance diff: 63000000000000'
Signer1 balance diff: 63000000000000
+ echo 'Signer2 balance diff: 0'
Signer2 balance diff: 0
+ echo 'Receiver balance diff: 100000000000000000'
Receiver balance diff: 100000000000000000
```